### PR TITLE
lineman-blog postinstall setup

### DIFF
--- a/lib/initializes-blog-templates.coffee
+++ b/lib/initializes-blog-templates.coffee
@@ -7,6 +7,11 @@ module.exports =
   initialize: (dir = process.cwd()) ->
     topDir = findsRoot.findTopPackageJson(dir)
     return unless isInstalledAsDependency(dir, topDir)
+    console.log """
+
+      Thanks for installing lineman-blog!
+
+      """
     createSamplePagesRelativeTo(topDir)
     createBlogTemplatesRelativeTo(topDir)
     createSamplePostsRelativeTo(topDir)
@@ -155,8 +160,6 @@ createBlogTemplatesRelativeTo = (dir) ->
   fs.writeFileSync "#{templatesPath}/wrapper.us", wrapperTemplate
 
   console.log """
-
-    Thanks for installing lineman-blog!
 
     We've added some basic blog templates to help you get started, here:
 

--- a/lib/initializes-blog-templates.coffee
+++ b/lib/initializes-blog-templates.coffee
@@ -155,11 +155,13 @@ createBlogTemplatesRelativeTo = (dir) ->
   fs.writeFileSync "#{templatesPath}/wrapper.us", wrapperTemplate
 
   console.log """
+
     Thanks for installing lineman-blog!
 
     We've added some basic blog templates to help you get started, here:
 
     #{templateFilepaths.join('\n')}
+
     """
 
 createSamplePostsRelativeTo = (dir) ->
@@ -205,6 +207,7 @@ createSamplePostsRelativeTo = (dir) ->
     We've also added some example posts here:
 
     #{postsPath}
+
     """
 
   createSamplePagesRelativeTo = (dir) ->

--- a/lib/initializes-blog-templates.coffee
+++ b/lib/initializes-blog-templates.coffee
@@ -8,15 +8,16 @@ module.exports =
     topDir = findsRoot.findTopPackageJson(dir)
     return unless isInstalledAsDependency(dir, topDir)
     createBlogTemplatesRelativeTo(topDir)
+    createSamplePostsRelativeTo(topDir)
 
 isInstalledAsDependency = (dir, topDir) ->
   topDir? && topDir != dir
 
 createBlogTemplatesRelativeTo = (dir) ->
-  mainTemplatesPath = path.join(dir, "app/templates")
+  templatesPath = path.join(dir, "app/templates")
   templateFilenames = "index archive page post wrapper".split(" ")
   extension         = ".us"
-  templateFilepaths = _(templateFilenames).map (filename) -> "#{mainTemplatesPath}/#{filename}#{extension}"
+  templateFilepaths = _(templateFilenames).map (filename) -> "#{templatesPath}/#{filename}#{extension}"
 
   indexTemplate = """
     <%= site.htmlFor(_(site.posts).last()) %>
@@ -107,11 +108,11 @@ createBlogTemplatesRelativeTo = (dir) ->
     </html>
     """
 
-  fs.writeFileSync "#{mainTemplatesPath}/index.us",   indexTemplate
-  fs.writeFileSync "#{mainTemplatesPath}/archive.us", archiveTemplate
-  fs.writeFileSync "#{mainTemplatesPath}/page.us",    pageTemplate
-  fs.writeFileSync "#{mainTemplatesPath}/post.us",    postTemplate
-  fs.writeFileSync "#{mainTemplatesPath}/wrapper.us", wrapperTemplate
+  fs.writeFileSync "#{templatesPath}/index.us",   indexTemplate
+  fs.writeFileSync "#{templatesPath}/archive.us", archiveTemplate
+  fs.writeFileSync "#{templatesPath}/page.us",    pageTemplate
+  fs.writeFileSync "#{templatesPath}/post.us",    postTemplate
+  fs.writeFileSync "#{templatesPath}/wrapper.us", wrapperTemplate
 
   console.log """
     Thanks for installing lineman-blog!
@@ -119,4 +120,48 @@ createBlogTemplatesRelativeTo = (dir) ->
     We've added some basic blog templates to help you get started, here:
 
     #{templateFilepaths.join('\n')}
+    """
+
+createSamplePostsRelativeTo = (dir) ->
+  postsPath = path.join(dir, "app/posts")
+  unless fs.existsSync(postsPath)
+    fs.mkdirSync(postsPath)
+
+  samplePostOne = """
+    ---
+    title: "A very nice title. With punctuation!"
+    author:
+      name: "Double Agent Man"
+    ---
+    I'm just an example post
+
+    > and I'm a quote of some markdown.
+
+    Yay.
+    """
+
+  samplePostTwo = """
+    I'm another example post
+
+    ``` coffeescript
+    andIAmSome = "CoffeeScript"
+    ```
+
+    Sweet.
+    """
+
+  samplePostThree = """
+    I'm a third example post.
+
+    I have **bold** text.
+    """
+
+  fs.writeFileSync "#{postsPath}/2013-03-17-example-post-1.md", samplePostOne
+  fs.writeFileSync "#{postsPath}/2013-03-16-example-post-2.md", samplePostTwo
+  fs.writeFileSync "#{postsPath}/2013-03-15-example-post-3.md", samplePostThree
+
+  console.log """
+    We've also added some example posts here:
+
+    #{postsPath}
     """

--- a/lib/initializes-blog-templates.coffee
+++ b/lib/initializes-blog-templates.coffee
@@ -14,7 +14,7 @@ isInstalledAsDependency = (dir, topDir) ->
 
 createBlogTemplatesRelativeTo = (dir) ->
   mainTemplatesPath = path.join(dir, "app/templates")
-  templateFilenames = ["index archive page post wrapper"].split(" ")
+  templateFilenames = "index archive page post wrapper".split(" ")
   extension         = ".us"
   templateFilepaths = _(templateFilenames).map (filename) -> path.join(dir, "#{mainTemplatesPath}/#{filename}#{extension}")
 

--- a/lib/initializes-blog-templates.coffee
+++ b/lib/initializes-blog-templates.coffee
@@ -7,11 +7,51 @@ module.exports =
   initialize: (dir = process.cwd()) ->
     topDir = findsRoot.findTopPackageJson(dir)
     return unless isInstalledAsDependency(dir, topDir)
+    createSamplePagesRelativeTo(topDir)
     createBlogTemplatesRelativeTo(topDir)
     createSamplePostsRelativeTo(topDir)
 
 isInstalledAsDependency = (dir, topDir) ->
   topDir? && topDir != dir
+
+createSamplePagesRelativeTo = (dir) ->
+  jsPath    = path.join(dir, "app/js")
+  pagesPath = path.join(dir, "app/pages")
+
+  if fs.existsSync "#{jsPath}/hello.coffee"
+    fs.unlinkSync "#{jsPath}/hello.coffee"
+
+  if fs.existsSync "#{pagesPath}/index.us"
+    fs.unlinkSync "#{pagesPath}/index.us"
+
+  sampleMarkdownPage = """
+    ---
+    title: "About us"
+    ---
+    # Markdown page
+
+    I'm just an about page formatted in _markdown_!
+    """
+
+  sampleHtmlPage = """
+    <!DOCTYPE html>
+    <html>
+      <body>
+        I'm just plain HTML.
+      </body>
+    </html>
+    """
+
+  fs.writeFileSync "#{pagesPath}/about.md", sampleMarkdownPage
+  fs.writeFileSync "#{pagesPath}/plain.html", sampleHtmlPage
+
+  console.log """
+
+    We've added some sample pages here:
+
+    #{pagesPath}
+
+    """
 
 createBlogTemplatesRelativeTo = (dir) ->
   templatesPath = path.join(dir, "app/templates")
@@ -161,7 +201,11 @@ createSamplePostsRelativeTo = (dir) ->
   fs.writeFileSync "#{postsPath}/2013-03-15-example-post-3.md", samplePostThree
 
   console.log """
+
     We've also added some example posts here:
 
     #{postsPath}
     """
+
+  createSamplePagesRelativeTo = (dir) ->
+    pagesPath = path.join(dir, "app/pages")

--- a/lib/initializes-blog-templates.coffee
+++ b/lib/initializes-blog-templates.coffee
@@ -16,7 +16,7 @@ createBlogTemplatesRelativeTo = (dir) ->
   mainTemplatesPath = path.join(dir, "app/templates")
   templateFilenames = "index archive page post wrapper".split(" ")
   extension         = ".us"
-  templateFilepaths = _(templateFilenames).map (filename) -> path.join(dir, "#{mainTemplatesPath}/#{filename}#{extension}")
+  templateFilepaths = _(templateFilenames).map (filename) -> "#{mainTemplatesPath}/#{filename}#{extension}"
 
   indexTemplate = """
     <%= site.htmlFor(_(site.posts).last()) %>
@@ -107,11 +107,11 @@ createBlogTemplatesRelativeTo = (dir) ->
     </html>
     """
 
-  fs.writeFileSync path.join(dir, "#{mainTemplatesPath}/index.us}"),   indexTemplate
-  fs.writeFileSync path.join(dir, "#{mainTemplatesPath}/archive.us}"), archiveTemplate
-  fs.writeFileSync path.join(dir, "#{mainTemplatesPath}/page.us}"),    pageTemplate
-  fs.writeFileSync path.join(dir, "#{mainTemplatesPath}/post.us}"),    postTemplate
-  fs.writeFileSync path.join(dir, "#{mainTemplatesPath}/wrapper.us}"), wrapperTemplate
+  fs.writeFileSync "#{mainTemplatesPath}/index.us",   indexTemplate
+  fs.writeFileSync "#{mainTemplatesPath}/archive.us", archiveTemplate
+  fs.writeFileSync "#{mainTemplatesPath}/page.us",    pageTemplate
+  fs.writeFileSync "#{mainTemplatesPath}/post.us",    postTemplate
+  fs.writeFileSync "#{mainTemplatesPath}/wrapper.us", wrapperTemplate
 
   console.log """
     Thanks for installing lineman-blog!

--- a/lib/initializes-blog-templates.coffee
+++ b/lib/initializes-blog-templates.coffee
@@ -1,0 +1,122 @@
+fs        = require("fs")
+path      = require("path")
+findsRoot = require("find-root-package")
+_         = require("underscore")
+
+module.exports =
+  initialize: (dir = process.cwd()) ->
+    topDir = findsRoot.findTopPackageJson(dir)
+    return unless isInstalledAsDependency(dir, topDir)
+    createBlogTemplatesRelativeTo(topDir)
+
+isInstalledAsDependency = (dir, topDir) ->
+  topDir? && topDir != dir
+
+createBlogTemplatesRelativeTo = (dir) ->
+  mainTemplatesPath = path.join(dir, "app/templates")
+  templateFilenames = ["index archive page post wrapper"].split(" ")
+  extension         = ".us"
+  templateFilepaths = _(templateFilenames).map (filename) -> path.join(dir, "#{mainTemplatesPath}/#{filename}#{extension}")
+
+  indexTemplate = """
+    <%= site.htmlFor(_(site.posts).last()) %>
+    """
+
+  archiveTemplate = """
+    <h1>archives</h1>
+    <ul>
+    <% _(site.posts).chain().reverse().each(function(post){ %>
+      <li>
+        <a href="/<%= post.htmlPath() %>"><%= post.title() %></a>
+      </li>
+    <% }) %>
+    </ul>
+    """
+
+  pageTemplate = """
+    <article class="page">
+      <div class="title">
+        <h1><%= post.title() %></h1>
+      </div>
+      <section>
+        <%= post.content() %>
+      </section>
+    </article>
+    """
+
+  postTemplate = """
+    <article class="post">
+      <div class="title">
+        <h1><a href="/<%= post.htmlPath() %>"><%= post.title() %></a></h1>
+        <p>
+          <%= post.date() %>
+          <% if(post.get('author')) { %>
+            by <%= post.get('author').name %>
+          <% } %>
+        </p>
+      </div>
+      <section>
+        <%= post.content() %>
+      </section>
+      <section class="navigation">
+          <% if(site.newerPost(post)) { %>
+            <span class="newer"><a href="/<%= site.newerPost(post).htmlPath() %>">&#8672;&nbsp;newer</a></span>
+          <% } %>
+          <% if(site.olderPost(post)) { %>
+            <span class="older"><a href="/<%= site.olderPost(post).htmlPath() %>">older&nbsp;&#8674;</a></span>
+          <% } %>
+        </section>
+      <section class="comments">
+        <% if(site.disqus) { %>
+          <div id="disqus_thread"></div>
+          <script type="text/javascript">
+            window.disqus_identifier="";
+            window.disqus_url="<%= site.url+"/"+post.htmlPath() %>";
+            window.disqus_title="<%= post.title() %>";
+          </script>
+            <script type="text/javascript" src="http://disqus.com/forums/<%= site.disqus %>/embed.js"></script>
+            <noscript><a href="http://<%= site.disqus %>.disqus.com/?url=ref">View the discussion thread.</a></noscript>
+        <% } %>
+      </section>
+    </article>
+    """
+
+  wrapperTemplate = """
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <link rel="stylesheet" type="text/css" href="<%= css %>" media="all" />
+        <link rel="alternate" type="application/rss+xml" title="<%= site.title %> - feed" href="/index.xml" />
+        <title><%= site.title %><%= post ? ' - '+post.title() : '' %></title>
+      </head>
+      <body>
+        <header>
+          <h1><%= site.title %></h1>
+          <nav>
+            <a href="/">home</a> | <a href="/archive.html">archives</a> | <a href="/about.html">about</a>
+          </nav>
+        </header>
+
+        <%= yield %>
+
+        <footer>
+          Copyright <%= site.author %>, <%= new Date().getFullYear() %>.
+        </footer>
+        <script type="text/javascript" src="<%= js %>"></script>
+      </body>
+    </html>
+    """
+
+  fs.writeFileSync path.join(dir, "#{mainTemplatesPath}/index.us}"),   indexTemplate
+  fs.writeFileSync path.join(dir, "#{mainTemplatesPath}/archive.us}"), archiveTemplate
+  fs.writeFileSync path.join(dir, "#{mainTemplatesPath}/page.us}"),    pageTemplate
+  fs.writeFileSync path.join(dir, "#{mainTemplatesPath}/post.us}"),    postTemplate
+  fs.writeFileSync path.join(dir, "#{mainTemplatesPath}/wrapper.us}"), wrapperTemplate
+
+  console.log """
+    Thanks for installing lineman-blog!
+
+    We've added some basic blog templates to help you get started, here:
+
+    #{templateFilepaths.join('\n')}
+    """

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "coffee-script": "~1.7.1",
     "grunt-markdown-blog": ">= 0.2.0",
-    "underscore": "~1.6.0"
+    "underscore": "~1.6.0",
+    "find-root-package": "0.0.1"
   },
   "peerDependencies": {
     "lineman": ">= 0.27.0"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/linemanjs/lineman-blog/issues"
   },
   "dependencies": {
-    "coffee-script": "~1.6.3",
+    "coffee-script": "~1.7.1",
     "grunt-markdown-blog": ">= 0.2.0",
     "underscore": "~1.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -16,15 +16,15 @@
   },
   "dependencies": {
     "coffee-script": "~1.6.3",
-    "grunt-markdown-blog": ">= 0.2.0"
+    "grunt-markdown-blog": ">= 0.2.0",
+    "underscore": "~1.6.0"
   },
   "peerDependencies": {
     "lineman": ">= 0.27.0"
   },
   "devDependencies": {
     "grunt": "^0.4.2",
-    "grunt-release": "^0.7.0",
-    "underscore": "~1.6.0"
+    "grunt-release": "^0.7.0"
   },
   "licenses": [
     {
@@ -32,6 +32,9 @@
       "url": "http://testdouble.mit-license.org"
     }
   ],
+  "scripts": {
+    "postinstall": "node script/postinstall.js"
+  },
   "keywords": [
     "lineman",
     "linemanplugin",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   },
   "devDependencies": {
     "grunt": "^0.4.2",
-    "grunt-release": "^0.7.0"
+    "grunt-release": "^0.7.0",
+    "underscore": "~1.6.0"
   },
   "licenses": [
     {

--- a/script/postinstall.js
+++ b/script/postinstall.js
@@ -1,0 +1,5 @@
+require('coffee-script/register');
+
+initializesBlogTemplates = require("./../lib/initializes-blog-templates");
+
+initializesBlogTemplates.initialize();


### PR DESCRIPTION
![screen shot 2014-04-12 at 11 28 18 pm](https://cloud.githubusercontent.com/assets/69559/2688657/2b24c3e2-c2bc-11e3-802e-4b48747be968.png)

I'm opening this as a work in progress, I'd like to pair with someone on a few things to improve this code but also to get the discussion going about how this could be useful. Some design goals for this PR are:
- let users easily generate a new blog `lineman new my-blog && npm install lineman-blog --save-dev`
- delete lineman-blog-template
- figure out a way to simplify and normalize sample file generation
- figure out the right way to delete directories and files from the archetype that aren't needed by a specific plugin like this
## Testing
1. Generate a new project with `lineman new my-blog`
2. Modify the new projects pacakage.json and add:

``` json
  "devDependencies": {
    "lineman-blog" : "git://github.com/linemanjs/lineman-blog.git#postinstall-stuffs"
  },
```
1. `npm install` to see the script in action

@searls @jasonkarns @jayharris to comment please :)
